### PR TITLE
Feature add proxy capacity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,12 @@ atlassian-ide-plugin.xml
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
+
+# ignore mocks (depend on projects)
+mocks/api*
+
+# ignore env config file
+api/config/dev.json
+
+# ignore proxy config file
+api/config/proxyConfig.json

--- a/api/config/proxyConfig-sample.json
+++ b/api/config/proxyConfig-sample.json
@@ -1,0 +1,35 @@
+{
+  "_meta" : {
+    "howTo" : "rename this file to proxyConfig",
+    "description" : "This file defines all urls which can be proxified (not mocked). In order to act as a simple proxy, the url must be define here with a value 'true'."
+  },
+  "host" : "localhost",
+  "port" : "9056",
+  "proxy" : {
+    "/api/.*/persons.*": false,
+    "/api/.*/sites/[^/]*/monthly-gas-consumptions.*": true,
+    "/api/.*/sites/[^/]*/compositions/gas-indexes": false,
+    "/api/.*/sites/[^/]*/yearly-gas-energies-comparisons.*": false,
+    "/api/.*/sites/[^/]*/gas-indexes.*": false,
+    "/api/.*/sites/[^/]*/gas-supply-contracts.*": false,
+    "/api/.*/sites/[^/]*/gas-supply-contract-changes.*": false,
+    "/api/.*/sites/[^/]*/gas-usage-breakdowns.*": false,
+    "/api/.*/sites/[^/]*/hourly-gas-heating-per-degree-savings.*": false,
+    "/api/.*/gas-indexes-contracts.*": false,
+    "/api/.*/offer-families/[^/]*/.*/gas-indexes-contracts.*": false,
+    "/api/.*/sites/[^/]*/gas-price-changes.*": false,
+    "/api/.*/sites/[^/]*/gas-analysis-parameters.*": false,
+    "/api/.*/sites/[^/]*/monthly-gas-usages-consumptions.*": false,
+    "/api/.*/sites/[^/]*/sensors/hourly-gas-consumptions.*": false,
+    "/api/.*/sites/[^/]*/sensors/daily-gas-consumptions.*": false,
+    "/api/.*/sites/[^/]*/sensors/monthly-gas-consumptions.*": false,
+    "/api/.*/sites/[^/]*/similar-home-monthly-gas-comparisons.*": false,
+    "/api/.*/sites/[^/]*/similar-home-yearly-gas-comparisons.*": false,
+    "/api/.*/sites/[^/]*/similar-home-monthly-elec-comparisons.*": false,
+    "/api/.*/sites/[^/]*/similar-home-yearly-elec-comparisons.*": false,
+    "/api/.*/sites/[^/]*/similar-home-yearly-target-elec-consumptions.*": false
+  }
+}
+
+
+

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -2,7 +2,6 @@
 let util = require('util');
 var MockCtrl = require('../controllers/MockCtrl');
 var cors = require('cors');
-var log = require('../utils/logger');
 
 module.exports = function(pApp, pLog) {
 

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -2,6 +2,7 @@
 let util = require('util');
 var MockCtrl = require('../controllers/MockCtrl');
 var cors = require('cors');
+var log = require('../utils/logger');
 
 module.exports = function(pApp, pLog) {
 

--- a/api/src/services/MockService.js
+++ b/api/src/services/MockService.js
@@ -1,0 +1,68 @@
+'use strict';
+let http = require('http');
+let log = require('../utils/logger');
+let FileLoaderService = require('../services/FileLoaderService.js');
+let FilePathBuilderService = require('../services/FilePathBuilderService.js');
+
+let MockService = function() {};
+
+MockService.buildMockResponse = function (request, response, url, envConfig) {
+  let queryString = null;
+  let httpCode = 201;
+  let rawContent = null;
+  let extension = 'json';
+  let location = null;
+  let delay = 1;
+  let method = request.method.toLowerCase();
+
+  // List every possible paths
+  let pathBuilder = new FilePathBuilderService();
+  let paths = pathBuilder.generatePaths(method, url, queryString);
+
+  // Find the file to load and extract the content
+  let fileLoader = new FileLoaderService();
+  let fileToLoad = fileLoader.find(paths.mocks);
+
+  let responseHeaders = {};
+
+  if (fileToLoad !== null) {
+    let fileData = fileLoader.load(fileToLoad, request, paths);
+    rawContent = fileData.rawContent;
+    httpCode = fileData.httpCode;
+    extension = fileData.extension;
+    location = fileData.location;
+    delay = fileData.delay;
+    responseHeaders['X-Mockiji-File'] = fileToLoad;
+    responseHeaders['X-Mockiji-Notices'] = fileData.notices;
+    responseHeaders['Cache-Control'] = 'no-cache';
+    if (location) {
+      responseHeaders['Location'] = location;
+    }
+    log.info({'method': method, 'url': url}, '[Response] ' + httpCode);
+  } else {
+    httpCode = envConfig.mock_file_not_found_http_code;
+    rawContent = {
+      'errorCode': httpCode,
+      'errorDescription': 'No mock file was found',
+      'evaluatedMockFilePaths': paths.mocks
+    };
+    log.info(rawContent, '[Response] Not Found');
+  }
+
+  // Set Response Headers
+  response.set(responseHeaders);
+
+  // Send Response
+  setTimeout(function() {
+    if(rawContent !== null && extension === 'html') {
+      response.status(httpCode).send(rawContent);
+    } else if(rawContent !== null) {
+      response.status(httpCode).json(rawContent);
+    } else {
+      response.set('X-Mockiji-Empty-Response-Body', true);
+      response.status(httpCode).send('');
+    }
+  }, delay);
+};
+
+module.exports = MockService;

--- a/api/src/services/ProxyConfigService.js
+++ b/api/src/services/ProxyConfigService.js
@@ -1,0 +1,39 @@
+'use strict';
+
+let fs = require('fs');
+let log = require('../utils/logger');
+
+let ProxyConfig = function() {};
+
+const CONFIG_FILE = "/config/proxyConfig.json";
+const DEFAULT_CONFIG = {
+  "proxy" : {}
+};
+
+ProxyConfig.load = function () {
+  let configPath = process.cwd() + CONFIG_FILE;
+  let config;
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    console.log("Proxy configuration from '" + configPath + "' file has been found and loaded");
+  } catch (e) {
+    console.log("No 'proxyConfig.json' file found (or invalid), using default empty configuration, all urls will be mocked");
+    config = DEFAULT_CONFIG;
+  };
+  return config;
+};
+
+ProxyConfig.isUrlProxyfied = function(proxyConfig, testedUrl) {
+  let urls = proxyConfig["proxy"];
+  let result = false;
+  for (let urlPatternProperty in urls) {
+    let urlMatching = new RegExp(urlPatternProperty).test(testedUrl);
+    if (urlMatching) {
+      result = urls[urlPatternProperty];
+      break;
+    }
+  };
+  return result;
+};
+
+module.exports = ProxyConfig;

--- a/api/src/services/RestClientProxyService.js
+++ b/api/src/services/RestClientProxyService.js
@@ -1,0 +1,31 @@
+'use strict';
+let http = require('http');
+let log = require('../utils/logger');
+
+let RestClientProxyService = function() {};
+
+RestClientProxyService.doHttpCall = function (request, response, url, proxyConfig) {
+  log.debug("[PROXIFIED URL] HTTP CALL :" + url);
+
+  var options = {
+    host: proxyConfig["host"],
+    port: proxyConfig["port"],
+    path: url,
+    method: request.method
+  };
+
+  http.request(options, function(httpRestResponse) {
+    var responseAsString = '';
+    httpRestResponse.setEncoding('utf8');
+    httpRestResponse.on('data', function (chunk) {
+      responseAsString += chunk;
+    });
+    httpRestResponse.on('end', function() {
+      response.set(httpRestResponse.headers);
+      response.status(httpRestResponse.statusCode);
+      response.send(responseAsString);
+    });
+  }).end();
+};
+
+module.exports = RestClientProxyService;


### PR DESCRIPTION
If you don't add a proxyConfig.json file, the default Mockiji behaviour is exactly the same as before. However, when you as a proxyConfig.json file (there is a sample), some url patterns (regexp) can be defined in order to Mockiji acts as a proxy for these urls.

At the moment, all proxified url are defined with a same host + port defined in the proxyConfig.json file. Maybe in the future we could improve this and make a finer configuration by setting a host+port for a set of proxified urls.