### PR TITLE
Add middlewares support

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -5,10 +5,15 @@ const cors = require('cors');
 const MockCtrl = require('../controllers/MockCtrl');
 
 module.exports = function({Configuration, Logger, app}) {
+  // Configuration middlewares
+  for (let middleware of Configuration.get('middlewares')) {
+    app.use(middleware);
+  }
+
   // Cross-domain management
   app.use(cors());
 
-  // Index route
+  // Public route
   app.use(express.static('./public'));
 
   // Mocks route

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,7 +8,10 @@ const MockCtrl = require('../controllers/MockCtrl');
 module.exports = function({Configuration, Logger, app}) {
   // Configuration middlewares
   for (let middleware of Configuration.get('middlewares')) {
-    app.use(middleware);
+    app.use(middleware({
+      configuration: Configuration,
+      logger: Logger,
+    }));
   }
 
   // Cross-domain management

--- a/src/utils/Configuration.js
+++ b/src/utils/Configuration.js
@@ -48,6 +48,11 @@ const SETTINGS_SCHEMA = {
       count:  3,
     }]
   },
+  middlewares: {
+    doc: 'Additional Express middlewares',
+    format: Array,
+    default: []
+  },
   authorization_header_replacements: {
     doc: 'An array of regexes and token replacement keys that can be used to change an URL part based on the content of the Authorization header',
     format: Array,


### PR DESCRIPTION
This PR allows to add middlewares in the Express stack used by Mockiji.

A Mockiji middleware is a JS function that is called by Mockiji (with the `logger` and the `configuration` as a parameter) and returns an Express middleware.

An example of how to use it to log response times:

```js
const Mockiji = require('mockiji');

const server = new Mockiji({
  configuration: {
    middlewares: [
      ({logger, configuration}) => {
        logger.info('Response time middleware loaded');

        return (req, res, next) => {
          // On request received
          const requestTime = Date.now();

          // On request end
          req.on('end', _ => {
            const deltaTime = Date.now() - requestTime;
            logger.debug(`Request ${req.method} ${req.originalUrl} took ${deltaTime}ms`);
          });

          // Call next middleware
          next();
        }
      }
    ]
  }
});

server.start();
```

A standalone middleware can also be created to reuse it between projects:

```js
const express = require('express');

module.exports = function({basePath} = {}) {
  return ({logger, configuration}) => {
    logger.info('Mockiji custom middleware loaded');

    const app = express();
    app.use(basePath, require('./routes'));
    return app;
  };
}
```

```js
const Mockiji = require('mockiji');

const server = new Mockiji({
  configuration: {
    middlewares: [
      require('my-custom-middleware')({basePath: '/dashboard'})
    ]
  }
});

server.start();
```